### PR TITLE
Issue24 prevent recursion

### DIFF
--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionPropertySource.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionPropertySource.java
@@ -24,26 +24,33 @@ public class CollectionPropertySource implements IPropertySource
 	 * @param element
 	 *          the element whose properties this instance represents
 	 */
-	public CollectionPropertySource(CollectionWrapper element)
+	public CollectionPropertySource(final CollectionWrapper element)
 	{
 		_collection = element;
+	}
+
+	@Override
+	public Object getEditableValue()
+	{
+		return _collection;
 	}
 
 	/**
 	 * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyDescriptors()
 	 */
+	@Override
 	public IPropertyDescriptor[] getPropertyDescriptors()
 	{
 		if (propertyDescriptors == null)
 		{
 			// Create a descriptor and set a category
-			PropertyDescriptor textDescriptor = new TextPropertyDescriptor(
+			final PropertyDescriptor textDescriptor = new TextPropertyDescriptor(
 					PROPERTY_NAME, "Name");
 			textDescriptor.setCategory("Label");
-			PropertyDescriptor sizeDescriptor = new PropertyDescriptor(
+			final PropertyDescriptor sizeDescriptor = new PropertyDescriptor(
 					PROPERTY_SIZE, "Size");
 			sizeDescriptor.setCategory("Metadata");
-			PropertyDescriptor descriptionDescriptor = new TextPropertyDescriptor(
+			final PropertyDescriptor descriptionDescriptor = new TextPropertyDescriptor(
 					PROPERTY_DESCRIPTION, "Description");
 			descriptionDescriptor.setCategory("Label");
 
@@ -53,14 +60,10 @@ public class CollectionPropertySource implements IPropertySource
 		return propertyDescriptors;
 	}
 
-	public Object getEditableValue()
+	@Override
+	public Object getPropertyValue(final Object id)
 	{
-		return _collection;
-	}
-
-	public Object getPropertyValue(Object id)
-	{
-		String prop = (String) id;
+		final String prop = (String) id;
 
 		if (prop.equals(PROPERTY_NAME))
 			return _collection.getCollection().getName();
@@ -72,21 +75,24 @@ public class CollectionPropertySource implements IPropertySource
 		return null;
 	}
 
-	public boolean isPropertySet(Object id)
+	@Override
+	public boolean isPropertySet(final Object id)
 	{
 		// TODO Auto-generated method stub
 		return false;
 	}
 
-	public void resetPropertyValue(Object id)
+	@Override
+	public void resetPropertyValue(final Object id)
 	{
 		// TODO Auto-generated method stub
 
 	}
 
-	public void setPropertyValue(Object id, Object value)
+	@Override
+	public void setPropertyValue(final Object id, final Object value)
 	{
-		String prop = (String) id;
+		final String prop = (String) id;
 
 		if (prop.equals(PROPERTY_NAME))
 			_collection.getCollection().setName((String) value);

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionWrapper.java
@@ -10,23 +10,15 @@ public class CollectionWrapper implements IAdaptable, LimpetWrapper
 	private final ICollection _collection;
 	private final LimpetWrapper _parent;
 
-	public CollectionWrapper(LimpetWrapper parent, ICollection collection)
+	public CollectionWrapper(final LimpetWrapper parent,
+			final ICollection collection)
 	{
 		_parent = parent;
 		_collection = collection;
 	}
 
-	public String toString()
-	{
-		return _collection.getName() + " (" + _collection.size() + " items)";
-	}
-
-	public ICollection getCollection()
-	{
-		return _collection;
-	}
-
-	public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter)
+	@Override
+	public Object getAdapter(@SuppressWarnings("rawtypes") final Class adapter)
 	{
 		if (adapter == IPropertySource.class)
 		{
@@ -39,6 +31,11 @@ public class CollectionWrapper implements IAdaptable, LimpetWrapper
 		return null;
 	}
 
+	public ICollection getCollection()
+	{
+		return _collection;
+	}
+
 	@Override
 	public LimpetWrapper getParent()
 	{
@@ -49,5 +46,11 @@ public class CollectionWrapper implements IAdaptable, LimpetWrapper
 	public Object getSubject()
 	{
 		return _collection;
+	}
+
+	@Override
+	public String toString()
+	{
+		return _collection.getName() + " (" + _collection.size() + " items)";
 	}
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CollectionWrapper.java
@@ -5,12 +5,14 @@ import info.limpet.ICollection;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.ui.views.properties.IPropertySource;
 
-public class CollectionWrapper implements IAdaptable
+public class CollectionWrapper implements IAdaptable, LimpetWrapper
 {
 	private final ICollection _collection;
+	private final LimpetWrapper _parent;
 
-	public CollectionWrapper(ICollection collection)
+	public CollectionWrapper(LimpetWrapper parent, ICollection collection)
 	{
+		_parent = parent;
 		_collection = collection;
 	}
 
@@ -35,5 +37,17 @@ public class CollectionWrapper implements IAdaptable
 			return _collection;
 		}
 		return null;
+	}
+
+	@Override
+	public LimpetWrapper getParent()
+	{
+		return _parent;
+	}
+
+	@Override
+	public Object getSubject()
+	{
+		return _collection;
 	}
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandPropertySource.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandPropertySource.java
@@ -23,23 +23,30 @@ public class CommandPropertySource implements IPropertySource
 	 * @param operationWrapper
 	 *          the element whose properties this instance represents
 	 */
-	public CommandPropertySource(CommandWrapper operationWrapper)
+	public CommandPropertySource(final CommandWrapper operationWrapper)
 	{
 		_operation = operationWrapper;
+	}
+
+	@Override
+	public Object getEditableValue()
+	{
+		return _operation;
 	}
 
 	/**
 	 * @see org.eclipse.ui.views.properties.IPropertySource#getPropertyDescriptors()
 	 */
+	@Override
 	public IPropertyDescriptor[] getPropertyDescriptors()
 	{
 		if (propertyDescriptors == null)
 		{
 			// Create a descriptor and set a category
-			PropertyDescriptor textDescriptor = new PropertyDescriptor(
+			final PropertyDescriptor textDescriptor = new PropertyDescriptor(
 					PROPERTY_NAME, "Name");
 			textDescriptor.setCategory("Label");
-			PropertyDescriptor descriptionDescriptor = new TextPropertyDescriptor(
+			final PropertyDescriptor descriptionDescriptor = new TextPropertyDescriptor(
 					PROPERTY_DESCRIPTION, "Description");
 			descriptionDescriptor.setCategory("Label");
 
@@ -49,14 +56,10 @@ public class CommandPropertySource implements IPropertySource
 		return propertyDescriptors;
 	}
 
-	public Object getEditableValue()
+	@Override
+	public Object getPropertyValue(final Object id)
 	{
-		return _operation;
-	}
-
-	public Object getPropertyValue(Object id)
-	{
-		String prop = (String) id;
+		final String prop = (String) id;
 
 		if (prop.equals(PROPERTY_NAME))
 			return _operation.getCommand().getTitle();
@@ -66,19 +69,22 @@ public class CommandPropertySource implements IPropertySource
 		return null;
 	}
 
-	public boolean isPropertySet(Object id)
+	@Override
+	public boolean isPropertySet(final Object id)
 	{
 		// TODO Auto-generated method stub
 		return false;
 	}
 
-	public void resetPropertyValue(Object id)
+	@Override
+	public void resetPropertyValue(final Object id)
 	{
 		// TODO Auto-generated method stub
 
 	}
 
-	public void setPropertyValue(Object id, Object value)
+	@Override
+	public void setPropertyValue(final Object id, final Object value)
 	{
 		throw new RuntimeException("cannot set properties for operation source");
 	}

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
@@ -5,12 +5,14 @@ import info.limpet.ICommand;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.ui.views.properties.IPropertySource;
 
-public class CommandWrapper implements IAdaptable
+public class CommandWrapper implements IAdaptable, LimpetWrapper
 {
 	private final ICommand _command;
+	private final LimpetWrapper _parent;
 
-	public CommandWrapper(ICommand prec)
+	public CommandWrapper(LimpetWrapper parent, ICommand prec)
 	{
+		_parent = parent;
 		_command = prec;
 	}
 
@@ -35,5 +37,17 @@ public class CommandWrapper implements IAdaptable
 			return _command;
 		}
 		return null;
+	}
+
+	@Override
+	public LimpetWrapper getParent()
+	{
+		return _parent;
+	}
+
+	@Override
+	public Object getSubject()
+	{
+		return _command;
 	}
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
@@ -10,23 +10,14 @@ public class CommandWrapper implements IAdaptable, LimpetWrapper
 	private final ICommand _command;
 	private final LimpetWrapper _parent;
 
-	public CommandWrapper(LimpetWrapper parent, ICommand prec)
+	public CommandWrapper(final LimpetWrapper parent, final ICommand prec)
 	{
 		_parent = parent;
 		_command = prec;
 	}
 
-	public String toString()
-	{
-		return _command.getTitle();
-	}
-
-	public ICommand getCommand()
-	{
-		return _command;
-	}
-
-	public Object getAdapter(@SuppressWarnings("rawtypes") Class adapter)
+	@Override
+	public Object getAdapter(@SuppressWarnings("rawtypes") final Class adapter)
 	{
 		if (adapter == IPropertySource.class)
 		{
@@ -39,6 +30,11 @@ public class CommandWrapper implements IAdaptable, LimpetWrapper
 		return null;
 	}
 
+	public ICommand getCommand()
+	{
+		return _command;
+	}
+
 	@Override
 	public LimpetWrapper getParent()
 	{
@@ -49,5 +45,11 @@ public class CommandWrapper implements IAdaptable, LimpetWrapper
 	public Object getSubject()
 	{
 		return _command;
+	}
+
+	@Override
+	public String toString()
+	{
+		return _command.getTitle();
 	}
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/CommandWrapper.java
@@ -7,10 +7,10 @@ import org.eclipse.ui.views.properties.IPropertySource;
 
 public class CommandWrapper implements IAdaptable, LimpetWrapper
 {
-	private final ICommand _command;
+	private final ICommand<?> _command;
 	private final LimpetWrapper _parent;
 
-	public CommandWrapper(final LimpetWrapper parent, final ICommand prec)
+	public CommandWrapper(final LimpetWrapper parent, final ICommand<?> prec)
 	{
 		_parent = parent;
 		_command = prec;
@@ -30,7 +30,7 @@ public class CommandWrapper implements IAdaptable, LimpetWrapper
 		return null;
 	}
 
-	public ICommand getCommand()
+	public ICommand<?> getCommand()
 	{
 		return _command;
 	}

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
@@ -165,13 +165,20 @@ public class DataModel implements ITreeContentProvider
 	{
 		final List<CollectionWrapper> list = new ArrayList<CollectionWrapper>();
 
-		final Iterator<ICollection> iter = _store.getAll().iterator();
-		while (iter.hasNext())
+		if (_store != null)
 		{
-			final ICollection iCollection = iter.next();
-			list.add(new CollectionWrapper(null, iCollection));
+			final Iterator<ICollection> iter = _store.getAll().iterator();
+			while (iter.hasNext())
+			{
+				final ICollection iCollection = iter.next();
+				list.add(new CollectionWrapper(null, iCollection));
+			}
 		}
-
+		else
+		{
+			throw new RuntimeException("We don't have a data store");
+		}
+		
 		return list.toArray();
 	}
 

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
@@ -34,14 +34,14 @@ public class DataModel implements ITreeContentProvider
 			res.add(dList);
 		}
 
-		final List<ICommand> dep = coll.getDependents();
+		final List<ICommand<?>> dep = coll.getDependents();
 		if (dep != null)
 		{
 			final NamedList dList = new NamedList(cw, "Dependents");
-			final Iterator<ICommand> dIter = dep.iterator();
+			final Iterator<ICommand<?>> dIter = dep.iterator();
 			while (dIter.hasNext())
 			{
-				final ICommand thisI = dIter.next();
+				final ICommand<?> thisI = dIter.next();
 				dList.add(new CommandWrapper(dList, thisI));
 			}
 
@@ -55,13 +55,13 @@ public class DataModel implements ITreeContentProvider
 
 	private void addCommandItems(final List<Object> res, final CommandWrapper cw)
 	{
-		final ICommand coll = cw.getCommand();
+		final ICommand<?> coll = cw.getCommand();
 
-		final List<ICollection> inp = coll.getInputs();
+		final List<? extends ICollection> inp = coll.getInputs();
 		if (inp != null)
 		{
 			final NamedList dList = new NamedList(cw, "Inputs");
-			final Iterator<ICollection> dIter = inp.iterator();
+			final Iterator<? extends ICollection> dIter = inp.iterator();
 			while (dIter.hasNext())
 			{
 				final ICollection thisI = dIter.next();
@@ -74,11 +74,11 @@ public class DataModel implements ITreeContentProvider
 			}
 		}
 
-		final List<ICollection> outp = coll.getOutputs();
+		final List<? extends ICollection> outp = coll.getOutputs();
 		if (outp != null)
 		{
 			final NamedList dList = new NamedList(cw, "Outputs");
-			final Iterator<ICollection> dIter = outp.iterator();
+			final Iterator<? extends ICollection> dIter = outp.iterator();
 			while (dIter.hasNext())
 			{
 				final ICollection thisI = dIter.next();

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/DataModel.java
@@ -11,140 +11,85 @@ import java.util.List;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 
+/**
+ * make the Limpet data store suitable for displaying in a tree control
+ * 
+ * @author ian
+ * 
+ */
 public class DataModel implements ITreeContentProvider
 {
 	private IStore _store;
 
-	public DataModel()
+	private void addCollectionItems(final List<Object> res,
+			final CollectionWrapper cw)
 	{
-	}
+		final ICollection coll = cw.getCollection();
 
-	public void inputChanged(Viewer v, Object oldInput, Object newInput)
-	{
-		if (newInput instanceof IStore)
+		final ICommand<?> prec = coll.getPrecedent();
+		if (prec != null)
 		{
-			_store = (IStore) newInput;
-		}
-		else
-		{
-			_store = null;
-		}
-	}
-
-	public void dispose()
-	{
-	}
-
-	public Object[] getElements(Object parent)
-	{
-
-		List<CollectionWrapper> list = new ArrayList<CollectionWrapper>();
-
-		Iterator<ICollection> iter = _store.getAll().iterator();
-		while (iter.hasNext())
-		{
-			ICollection iCollection = iter.next();
-			list.add(new CollectionWrapper(null, iCollection));
+			final NamedList dList = new NamedList(cw, "Precedents");
+			dList.add(new CommandWrapper(dList, prec));
+			res.add(dList);
 		}
 
-		return list.toArray();
-	}
-
-	@SuppressWarnings(
-	{ "rawtypes", "unchecked" })
-	public Object[] getChildren(Object parentElement)
-	{
-		List<Object> res = new ArrayList<Object>();
-
-		if (parentElement instanceof CollectionWrapper)
+		final List<ICommand> dep = coll.getDependents();
+		if (dep != null)
 		{
-			// see if it has predecessors or successors
-			CollectionWrapper cw = (CollectionWrapper) parentElement;
-			ICollection coll = cw.getCollection();
-
-			ICommand<?> prec = coll.getPrecedent();
-			if (prec != null)
+			final NamedList dList = new NamedList(cw, "Dependents");
+			final Iterator<ICommand> dIter = dep.iterator();
+			while (dIter.hasNext())
 			{
-				NamedList dList = new NamedList(cw, "Precedents");
-				dList.add(new CommandWrapper(dList, prec));
+				final ICommand thisI = dIter.next();
+				dList.add(new CommandWrapper(dList, thisI));
+			}
+
+			// did we find any?
+			if (dList.size() > 0)
+			{
 				res.add(dList);
 			}
-
-			List<ICommand> dep = coll.getDependents();
-			if (dep != null)
-			{
-				NamedList dList = new NamedList(cw, "Dependents");
-				Iterator<ICommand> dIter = dep.iterator();
-				while (dIter.hasNext())
-				{
-					ICommand thisI = (ICommand) dIter.next();
-					dList.add(new CommandWrapper(dList, thisI));
-				}
-
-				// did we find any?
-				if (dList.size() > 0)
-				{
-					res.add(dList);
-				}
-			}
 		}
-		else if (parentElement instanceof CommandWrapper)
-		{
-			// see if it has predecessors or successors
-			CommandWrapper cw = (CommandWrapper) parentElement;
-			ICommand coll = cw.getCommand();
-
-			List<ICollection> inp = coll.getInputs();
-			if (inp != null)
-			{
-				NamedList dList = new NamedList(cw, "Inputs");
-				Iterator<ICollection> dIter = inp.iterator();
-				while (dIter.hasNext())
-				{
-					ICollection thisI = (ICollection) dIter.next();
-					dList.add(new CollectionWrapper(dList, thisI));
-				}
-				// did we find any?
-				if (dList.size() > 0)
-				{
-					res.add(dList);
-				}
-			}
-
-			List<ICollection> outp = coll.getOutputs();
-			if (outp != null)
-			{
-				NamedList dList = new NamedList(cw, "Outputs");
-				Iterator<ICollection> dIter = outp.iterator();
-				while (dIter.hasNext())
-				{
-					ICollection thisI = (ICollection) dIter.next();
-					dList.add(new CollectionWrapper(dList, thisI));
-				}
-				// did we find any?
-				if (dList.size() > 0)
-				{
-					res.add(dList);
-				}
-			}
-		}
-		else if (parentElement instanceof List)
-		{
-			List list = (List) parentElement;
-			Iterator iter = list.iterator();
-			while (iter.hasNext())
-			{
-				res.add(iter.next());
-			}
-		}
-
-		Object[] resArray = res.toArray();
-		return resArray;
 	}
 
-	public Object getParent(Object element)
+	private void addCommandItems(final List<Object> res, final CommandWrapper cw)
 	{
-		return null;
+		final ICommand coll = cw.getCommand();
+
+		final List<ICollection> inp = coll.getInputs();
+		if (inp != null)
+		{
+			final NamedList dList = new NamedList(cw, "Inputs");
+			final Iterator<ICollection> dIter = inp.iterator();
+			while (dIter.hasNext())
+			{
+				final ICollection thisI = dIter.next();
+				dList.add(new CollectionWrapper(dList, thisI));
+			}
+			// did we find any?
+			if (dList.size() > 0)
+			{
+				res.add(dList);
+			}
+		}
+
+		final List<ICollection> outp = coll.getOutputs();
+		if (outp != null)
+		{
+			final NamedList dList = new NamedList(cw, "Outputs");
+			final Iterator<ICollection> dIter = outp.iterator();
+			while (dIter.hasNext())
+			{
+				final ICollection thisI = dIter.next();
+				dList.add(new CollectionWrapper(dList, thisI));
+			}
+			// did we find any?
+			if (dList.size() > 0)
+			{
+				res.add(dList);
+			}
+		}
 	}
 
 	/**
@@ -155,7 +100,7 @@ public class DataModel implements ITreeContentProvider
 	 *          the object we're considering
 	 * @return yes/no for if it's at the top of the folder tree
 	 */
-	protected boolean alreadyShown(LimpetWrapper element)
+	protected boolean alreadyShown(final LimpetWrapper element)
 	{
 		final LimpetWrapper lookingFor = element;
 		LimpetWrapper current = element;
@@ -179,13 +124,71 @@ public class DataModel implements ITreeContentProvider
 		return found;
 	}
 
-	public boolean hasChildren(Object element)
+	@Override
+	public void dispose()
+	{
+	}
+
+	@Override
+	@SuppressWarnings(
+	{ "rawtypes" })
+	public Object[] getChildren(final Object parentElement)
+	{
+		final List<Object> res = new ArrayList<Object>();
+
+		if (parentElement instanceof CollectionWrapper)
+		{
+			// see if it has predecessors or successors
+			addCollectionItems(res, (CollectionWrapper) parentElement);
+		}
+		else if (parentElement instanceof CommandWrapper)
+		{
+			// see if it has predecessors or successors
+			addCommandItems(res, (CommandWrapper) parentElement);
+		}
+		else if (parentElement instanceof List)
+		{
+			final List list = (List) parentElement;
+			final Iterator iter = list.iterator();
+			while (iter.hasNext())
+			{
+				res.add(iter.next());
+			}
+		}
+
+		final Object[] resArray = res.toArray();
+		return resArray;
+	}
+
+	@Override
+	public Object[] getElements(final Object parent)
+	{
+		final List<CollectionWrapper> list = new ArrayList<CollectionWrapper>();
+
+		final Iterator<ICollection> iter = _store.getAll().iterator();
+		while (iter.hasNext())
+		{
+			final ICollection iCollection = iter.next();
+			list.add(new CollectionWrapper(null, iCollection));
+		}
+
+		return list.toArray();
+	}
+
+	@Override
+	public Object getParent(final Object element)
+	{
+		return null;
+	}
+
+	@Override
+	public boolean hasChildren(final Object element)
 	{
 		boolean res = false;
 
 		if (element instanceof LimpetWrapper)
 		{
-			LimpetWrapper core = (LimpetWrapper) element;
+			final LimpetWrapper core = (LimpetWrapper) element;
 
 			// has it already been shown?
 			if (!alreadyShown(core))
@@ -193,30 +196,44 @@ public class DataModel implements ITreeContentProvider
 				if (element instanceof CollectionWrapper)
 				{
 					// see if it has predecessors or successors
-					CollectionWrapper cw = (CollectionWrapper) element;
-					ICollection coll = cw.getCollection();
+					final CollectionWrapper cw = (CollectionWrapper) element;
+					final ICollection coll = cw.getCollection();
 
-					boolean hasDependents = coll.getDependents().size() > 0;
-					boolean hasPrecedents = coll.getPrecedent() != null;
+					final boolean hasDependents = coll.getDependents().size() > 0;
+					final boolean hasPrecedents = coll.getPrecedent() != null;
 					res = (hasDependents || hasPrecedents);
 				}
 				else if (element instanceof CommandWrapper)
 				{
 					// see if it has predecessors or successors
-					CommandWrapper cw = (CommandWrapper) element;
-					ICommand<?> comm = cw.getCommand();
+					final CommandWrapper cw = (CommandWrapper) element;
+					final ICommand<?> comm = cw.getCommand();
 
 					res = ((comm.getInputs().size() > 0) || (comm.getOutputs().size() > 0));
 				}
 				else if (element instanceof ArrayList)
 				{
-					ArrayList<?> ar = (ArrayList<?>) element;
+					final ArrayList<?> ar = (ArrayList<?>) element;
 					return ar.size() > 0;
 				}
 			}
 		}
 
 		return res;
+	}
+
+	@Override
+	public void inputChanged(final Viewer v, final Object oldInput,
+			final Object newInput)
+	{
+		if (newInput instanceof IStore)
+		{
+			_store = (IStore) newInput;
+		}
+		else
+		{
+			_store = null;
+		}
 	}
 
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/LimpetWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/LimpetWrapper.java
@@ -1,0 +1,8 @@
+package info.limpet.rcp.data_provider.data;
+
+
+public interface LimpetWrapper
+{
+	public LimpetWrapper getParent();
+	public Object getSubject();
+}

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/LimpetWrapper.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/LimpetWrapper.java
@@ -1,8 +1,24 @@
 package info.limpet.rcp.data_provider.data;
 
-
+/**
+ * objects that are used in the Limpet object tree
+ * 
+ * @author ian
+ * 
+ */
 public interface LimpetWrapper
 {
+	/**
+	 * retrieve the parent of the current object
+	 * 
+	 * @return
+	 */
 	public LimpetWrapper getParent();
+
+	/**
+	 * retrieve the pure limpet object that this instance is wrapping
+	 * 
+	 * @return
+	 */
 	public Object getSubject();
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
  * @param <Object>
  */
 @SuppressWarnings("hiding")
-public class NamedList<Object> extends ArrayList<Object>
+public class NamedList<Object> extends ArrayList<Object> implements LimpetWrapper
 {
 
 	/**
@@ -17,15 +17,29 @@ public class NamedList<Object> extends ArrayList<Object>
 	 */
 	private static final long serialVersionUID = 1L;
 	final private String _name;
+	private final LimpetWrapper _parent;
 	
-	public NamedList(String name)
+	public NamedList(LimpetWrapper parent, String name)
 	{
 		_name = name;
+		_parent = parent;
 	}
 	
 	public String toString()
 	{
 		return _name;
+	}
+
+	@Override
+	public LimpetWrapper getParent()
+	{
+		return _parent;
+	}
+
+	@Override
+	public java.lang.Object getSubject()
+	{
+		return this;
 	}
 	
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
@@ -2,14 +2,16 @@ package info.limpet.rcp.data_provider.data;
 
 import java.util.ArrayList;
 
-/** utility class that stores a list of items, with a particular name
+/**
+ * utility class that stores a list of items, with a specific name
  * 
  * @author ian
- *
+ * 
  * @param <Object>
  */
 @SuppressWarnings("hiding")
-public class NamedList<Object> extends ArrayList<Object> implements LimpetWrapper
+public class NamedList<Object> extends ArrayList<Object> implements
+		LimpetWrapper
 {
 
 	/**
@@ -18,16 +20,11 @@ public class NamedList<Object> extends ArrayList<Object> implements LimpetWrappe
 	private static final long serialVersionUID = 1L;
 	final private String _name;
 	private final LimpetWrapper _parent;
-	
-	public NamedList(LimpetWrapper parent, String name)
+
+	public NamedList(final LimpetWrapper parent, final String name)
 	{
 		_name = name;
 		_parent = parent;
-	}
-	
-	public String toString()
-	{
-		return _name;
 	}
 
 	@Override
@@ -41,5 +38,11 @@ public class NamedList<Object> extends ArrayList<Object> implements LimpetWrappe
 	{
 		return this;
 	}
-	
+
+	@Override
+	public String toString()
+	{
+		return _name;
+	}
+
 }

--- a/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/data_provider/data/NamedList.java
@@ -9,8 +9,7 @@ import java.util.ArrayList;
  * 
  * @param <Object>
  */
-@SuppressWarnings("hiding")
-public class NamedList<Object> extends ArrayList<Object> implements
+public class NamedList extends ArrayList<Object> implements
 		LimpetWrapper
 {
 
@@ -18,7 +17,7 @@ public class NamedList<Object> extends ArrayList<Object> implements
 	 * 
 	 */
 	private static final long serialVersionUID = 1L;
-	final private String _name;
+	private final String _name;
 	private final LimpetWrapper _parent;
 
 	public NamedList(final LimpetWrapper parent, final String name)

--- a/info.limpet.test/src/info/limpet/data/TestOperations.java
+++ b/info.limpet.test/src/info/limpet/data/TestOperations.java
@@ -169,45 +169,45 @@ public class TestOperations extends TestCase
 		InMemoryStore store = new InMemoryStore();
 		assertEquals("store empty", 0, store.rootSize());
 		
-		Collection<ICommand> actions = new AddQuantityOperation().actionsFor(selection, store );
+		Collection<ICommand<?>> actions = new AddQuantityOperation().actionsFor(selection, store );
 		
 		assertEquals("correct number of actions returned", 1, actions.size());
 		
-		ICommand addAction = actions.iterator().next();
+		ICommand<?> addAction = actions.iterator().next();
 		addAction.execute();
 		
 		assertEquals("new collection added to store", 1, store.rootSize());
 		
 		ICollection firstItem = store.getRoot().get(0);
-		ICommand precedent = firstItem.getPrecedent();
+		ICommand<?> precedent = firstItem.getPrecedent();
 		assertNotNull("has precedent", precedent);
 		assertEquals("Correct name", "Add series", precedent.getTitle());
 		
-		List<ICollection> inputs = precedent.getInputs();
+		List<? extends ICollection> inputs = precedent.getInputs();
 		assertEquals("Has both precedents", 2, inputs.size());
 
-		Iterator<ICollection> iIter = inputs.iterator();
+		Iterator<? extends ICollection> iIter = inputs.iterator();
 		while (iIter.hasNext())
 		{
 			ICollection thisC = (ICollection) iIter.next();
-			List<ICommand> deps = thisC.getDependents();
+			List<ICommand<?>> deps = thisC.getDependents();
 			assertEquals("has a depedent", 1, deps.size());
-			Iterator<ICommand> dIter = deps.iterator();
+			Iterator<ICommand<?>> dIter = deps.iterator();
 			while (dIter.hasNext())
 			{
-				ICommand iCommand = (ICommand) dIter.next();
+				ICommand<?> iCommand = (ICommand<?>) dIter.next();
 				assertEquals("Correct dependent", precedent, iCommand);
 			}
 		}
 		
-		List<ICollection> outputs = precedent.getOutputs();
+		List<? extends ICollection> outputs = precedent.getOutputs();
 		assertEquals("Has both dependents", 1, outputs.size());
 		
-		Iterator<ICollection> oIter = outputs.iterator();
+		Iterator<? extends ICollection> oIter = outputs.iterator();
 		while (oIter.hasNext())
 		{
 			ICollection thisC = (ICollection) oIter.next();
-			ICommand dep = thisC.getPrecedent();
+			ICommand<?> dep = thisC.getPrecedent();
 			assertNotNull("has a depedent", dep);
 			assertEquals("Correct dependent", precedent, dep);
 		}

--- a/info.limpet/src/info/limpet/ICollection.java
+++ b/info.limpet/src/info/limpet/ICollection.java
@@ -9,9 +9,9 @@ public interface ICollection
 	public int size();
 	public boolean isQuantity();
 	public boolean isTemporal();
-	public abstract List<ICommand> getDependents();
-	public abstract ICommand getPrecedent();
-	public void addDependent(ICommand addQuantityValues);
+	public abstract List<ICommand<?>> getDependents();
+	public abstract ICommand<?> getPrecedent();
+	public void addDependent(ICommand<?> addQuantityValues);
 	public abstract void setDescription(String description);
 	public abstract String getDescription();
 

--- a/info.limpet/src/info/limpet/analysis/SimpleDescriptiveQuantity.java
+++ b/info.limpet/src/info/limpet/analysis/SimpleDescriptiveQuantity.java
@@ -10,9 +10,7 @@ import java.util.List;
 
 import javax.measure.Quantity;
 
-import org.apache.commons.math3.random.EmpiricalDistribution;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 public abstract class SimpleDescriptiveQuantity extends CoreAnalysis
 {

--- a/info.limpet/src/info/limpet/data/impl/ObjectCollection.java
+++ b/info.limpet/src/info/limpet/data/impl/ObjectCollection.java
@@ -14,19 +14,19 @@ public class ObjectCollection<T extends Object> implements IObjectCollection<T>
 	ArrayList<T> _values = new ArrayList<T>();
 	private String _name;
 	private String _description = "";
-	private final ICommand _precedent;
-	private final List<ICommand> _dependents;
+	private final ICommand<?> _precedent;
+	private final List<ICommand<?>> _dependents;
 	
 	public ObjectCollection(String name)
 	{
 		this(name, null);
 	}
 
-	public ObjectCollection(String name, ICommand precedent)
+	public ObjectCollection(String name, ICommand<?> precedent)
 	{
 		_name = name;
 		_precedent = precedent;
-		_dependents = new ArrayList<ICommand>();
+		_dependents = new ArrayList<ICommand<?>>();
 	}	
 	
 	@Override
@@ -78,19 +78,19 @@ public class ObjectCollection<T extends Object> implements IObjectCollection<T>
 	}
 
 	@Override
-	public ICommand getPrecedent()
+	public ICommand<?> getPrecedent()
 	{
 		return _precedent;
 	}
 
 	@Override
-	public List<ICommand> getDependents()
+	public List<ICommand<?>> getDependents()
 	{
 		return _dependents;
 	}
 
 	@Override
-	public void addDependent(ICommand command)
+	public void addDependent(ICommand<?> command)
 	{
 		_dependents.add(command);
 	}

--- a/info.limpet/src/info/limpet/data/impl/QuantityCollection.java
+++ b/info.limpet/src/info/limpet/data/impl/QuantityCollection.java
@@ -21,7 +21,7 @@ public class QuantityCollection<T extends Quantity<T>> extends
 		this(name, null, units);
 	}
 
-	public QuantityCollection(String name, ICommand precedent, Unit<T> units)
+	public QuantityCollection(String name, ICommand<?> precedent, Unit<T> units)
 	{
 		super(name, precedent);
 		_units = units;

--- a/info.limpet/src/info/limpet/data/impl/TemporalObjectCollection.java
+++ b/info.limpet/src/info/limpet/data/impl/TemporalObjectCollection.java
@@ -21,7 +21,7 @@ public class TemporalObjectCollection<T extends Object> extends
 		this(name, null);
 	}
 
-	public TemporalObjectCollection(String name, ICommand precedent)
+	public TemporalObjectCollection(String name, ICommand<?> precedent)
 	{
 		super(name, precedent);
 		_tSupport = new TimeHelper(_times);

--- a/info.limpet/src/info/limpet/data/impl/TemporalQuantityCollection.java
+++ b/info.limpet/src/info/limpet/data/impl/TemporalQuantityCollection.java
@@ -25,7 +25,7 @@ public class TemporalQuantityCollection<T extends Quantity<T>> extends
 		this(name, null, units);
 	}
 	
-	public TemporalQuantityCollection(String name, ICommand precedent, Unit<T> units)
+	public TemporalQuantityCollection(String name, ICommand<?> precedent, Unit<T> units)
 	{
 		super(name);
 		_myUnits = units;


### PR DESCRIPTION
when we show the audit trail for collections we currently allow some recursion, where the user can expose the details of an object they are already looking at.

Introduce changes to prevent this.  So, an object that is being examined cannot be opened again from within its children.
