### PR TITLE
Issue #125 - Drag drop between layers

### DIFF
--- a/info.limpet.rcp/src/info/limpet/rcp/editors/dnd/DataManagerDropAdapter.java
+++ b/info.limpet.rcp/src/info/limpet/rcp/editors/dnd/DataManagerDropAdapter.java
@@ -53,6 +53,8 @@ public class DataManagerDropAdapter extends ViewerDropAdapter
 
 			final boolean validTarget;
 			final Object target = getCurrentTarget();
+			if (target == getSelectedObject())
+				return false;
 			if (target == null)
 				validTarget = true;
 			else if (target instanceof GroupWrapper)
@@ -103,6 +105,7 @@ public class DataManagerDropAdapter extends ViewerDropAdapter
 						_store.add(item);
 					}
 				}
+				changed();
 				return true;
 			}
 

--- a/info.limpet/src/info/limpet/data/commands/AbstractCommand.java
+++ b/info.limpet/src/info/limpet/data/commands/AbstractCommand.java
@@ -33,7 +33,7 @@ public abstract class AbstractCommand<T extends IStoreItem> implements
 	 */
 	private boolean dynamic = true;
 	final private String outputName;
-	final transient private UUID uuid;
+	transient private UUID uuid;
 
 	public AbstractCommand(String title, String description, String outputName,
 			IStore store, boolean canUndo, boolean canRedo, List<T> inputs)
@@ -44,7 +44,6 @@ public abstract class AbstractCommand<T extends IStoreItem> implements
 		this.canUndo = canUndo;
 		this.canRedo = canRedo;
 		this.outputName = outputName;
-		this.uuid = UUID.randomUUID();
 
 		if (inputs != null)
 		{
@@ -62,6 +61,10 @@ public abstract class AbstractCommand<T extends IStoreItem> implements
 	@Override
 	public UUID getUUID()
 	{
+		if (uuid == null)
+		{
+			uuid = UUID.randomUUID();
+		}
 		return uuid;
 	}
 

--- a/info.limpet/src/info/limpet/data/impl/ObjectCollection.java
+++ b/info.limpet/src/info/limpet/data/impl/ObjectCollection.java
@@ -20,7 +20,7 @@ public class ObjectCollection<T extends Object> implements IObjectCollection<T>
 	private String description = "";
 	private final ICommand<?> precedent;
 	private final List<ICommand<?>> dependents;
-	private transient final UUID uuid;
+	private transient UUID uuid;
 
 	// note: we make the change support listeners transient, since
 	// they refer to UI elements that we don't persist
@@ -38,7 +38,6 @@ public class ObjectCollection<T extends Object> implements IObjectCollection<T>
 		this.name = name;
 		this.precedent = precedent;
 		dependents = new ArrayList<ICommand<?>>();
-		uuid = UUID.randomUUID();
 
 		// setup helpers
 		initListeners();
@@ -49,6 +48,10 @@ public class ObjectCollection<T extends Object> implements IObjectCollection<T>
 	@Override
 	public UUID getUUID()
 	{
+		if (uuid == null)
+		{
+			uuid = UUID.randomUUID();
+		}
 		return uuid;
 	}
 

--- a/info.limpet/src/info/limpet/data/store/InMemoryStore.java
+++ b/info.limpet/src/info/limpet/data/store/InMemoryStore.java
@@ -27,7 +27,7 @@ public class InMemoryStore implements IStore, IChangeListener
 		private static final long serialVersionUID = 1L;
 		private String _name;
 		private IStoreGroup _parent;
-		final transient private UUID uuid;
+		transient private UUID uuid;
 
 		// note: we make the change support listeners transient, since
 		// they refer to UI elements that we don't persist
@@ -36,12 +36,15 @@ public class InMemoryStore implements IStore, IChangeListener
 		public StoreGroup(String name)
 		{
 			_name = name;
-			uuid = UUID.randomUUID();
 		}
 
 		@Override
 		public UUID getUUID()
 		{
+			if (uuid == null)
+			{
+				uuid = UUID.randomUUID();
+			}
 			return uuid;
 		}
 


### PR DESCRIPTION
The commit fixes two issues:
- when opening an editor from file, UUIDs aren't restored,
  Drag&Drop throws NPE
- when dropping an item to itself, it is just removed

Also, now UUID is created only when it's needed (when start dragging)
