### PR TITLE
added bundle base version support to make plugins independent  from parent

### DIFF
--- a/info.limpet.feature/pom.xml
+++ b/info.limpet.feature/pom.xml
@@ -6,6 +6,7 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.feature</artifactId>

--- a/info.limpet.libs/pom.xml
+++ b/info.limpet.libs/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.libs</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.0.6-SNAPSHOT</version>
 </project>

--- a/info.limpet.rcp/pom.xml
+++ b/info.limpet.rcp/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.rcp</artifactId>
+  <version>1.0.6-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/info.limpet.sample_data/pom.xml
+++ b/info.limpet.sample_data/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.sample_data</artifactId>
+  <version>1.0.6-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/info.limpet.stackedcharts.model/META-INF/MANIFEST.MF
+++ b/info.limpet.stackedcharts.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Limpet UI
 Bundle-SymbolicName: info.limpet.stackedcharts.model;singleton:=true
-Bundle-Version: 1.0.6.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: MWC
 Bundle-Localization: plugin

--- a/info.limpet.stackedcharts.model/pom.xml
+++ b/info.limpet.stackedcharts.model/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.stackedcharts.model</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/info.limpet.stackedcharts.ui/META-INF/MANIFEST.MF
+++ b/info.limpet.stackedcharts.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Stackedcharts Editor
 Bundle-SymbolicName: info.limpet.stackedcharts.ui;singleton:=true
-Bundle-Version: 1.0.6.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: info.limpet.stackedcharts.ui.editor.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.ui,

--- a/info.limpet.stackedcharts.ui/pom.xml
+++ b/info.limpet.stackedcharts.ui/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.stackedcharts.ui</artifactId>
+   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/info.limpet.ui/pom.xml
+++ b/info.limpet.ui/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet.ui</artifactId>
+  <version>1.0.6-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/info.limpet/pom.xml
+++ b/info.limpet/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>info.limpet</artifactId>
+  <version>1.0.6-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.geotools/pom.xml
+++ b/org.geotools/pom.xml
@@ -6,8 +6,10 @@
     <groupId>info.limpet</groupId>
     <artifactId>parent</artifactId>
     <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent>
   <groupId>info.limpet</groupId>
   <artifactId>org.geotools</artifactId>
+  <version>1.0.6-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.mwc.cmap.jfreechart/META-INF/MANIFEST.MF
+++ b/org.mwc.cmap.jfreechart/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JFreeChart
 Bundle-SymbolicName: org.mwc.cmap.jfreechart;singleton:=true
-Bundle-Version: 1.0.6.qualifier
+Bundle-Version: 1.0.21.qualifier
 Bundle-Activator: org.mwc.cmap.jfreechart.Activator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swt

--- a/org.mwc.cmap.jfreechart/pom.xml
+++ b/org.mwc.cmap.jfreechart/pom.xml
@@ -10,4 +10,5 @@
   <groupId>info.limpet</groupId>
   <artifactId>org.mwc.cmap.jfreechart</artifactId>
   <packaging>eclipse-plugin</packaging>
+  <version>1.0.21-SNAPSHOT</version>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <tycho-repo.url>https://oss.sonatype.org/content/groups/public/</tycho-repo.url>
     <jacoco.destFile>../target/jacoco.exec</jacoco.destFile>
     <coverage.filter>info.limpet.*</coverage.filter>
+    <limpet.base.version>${project.version}</limpet.base.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
I have switch back **xx.stackedcharts.model** & **xx.stackedcharts.ui** to version **1.0.0** 
and  org.mwc.cmap.jfreechart to match debrief version  **1.0.21**
