### PR TITLE
relayout features to avoid conflicts when import on Debrief target patform

### DIFF
--- a/info.limpet.feature.libs/.project
+++ b/info.limpet.feature.libs/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>info.limpet.feature.libs</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/info.limpet.feature.libs/build.properties
+++ b/info.limpet.feature.libs/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/info.limpet.feature.libs/feature.properties
+++ b/info.limpet.feature.libs/feature.properties
@@ -1,0 +1,5 @@
+featureName=Limpet Libs feature
+
+providerName=MWC
+
+description=Lightweight InforMation ProcEssing Toolkit

--- a/info.limpet.feature.libs/feature.xml
+++ b/info.limpet.feature.libs/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="info.limpet.feature"
+      id="info.limpet.feature.libs"
       label="%featureName"
       version="1.0.6.qualifier"
       provider-name="%providerName"
@@ -183,27 +183,42 @@ Library.
    </url>
 
    <plugin
-         id="info.limpet"
+         id="org.eclipse.emf.ecore"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="info.limpet.libs"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
-         id="info.limpet.stackedcharts.ui"
+         id="org.eclipse.emf.ecore.xmi"
          download-size="0"
          install-size="0"
          version="0.0.0"
          unpack="false"/>
 
    <plugin
-         id="info.limpet.stackedcharts.model"
+         id="org.eclipse.gef"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.mwc.cmap.jfreechart"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.emf.common"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.draw2d"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/info.limpet.feature.libs/pom.xml
+++ b/info.limpet.feature.libs/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>info.limpet</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.6-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+  <groupId>info.limpet</groupId>
+  <artifactId>info.limpet.feature.libs</artifactId>
+  <packaging>eclipse-feature</packaging>
+  
+</project>

--- a/info.limpet.product/category.xml
+++ b/info.limpet.product/category.xml
@@ -12,5 +12,8 @@
    <feature url="features/info.limpet.ui.feature_0.0.0.jar" id="info.limpet.ui.feature" version="0.0.0">
       <category name="info.limpet.updatesite"/>
    </feature>
+   <feature url="features/info.limpet.feature.libs_1.0.6.qualifier.jar" id="info.limpet.feature.libs" version="1.0.6.qualifier">
+      <category name="info.limpet.updatesite"/>
+   </feature>
    <category-def name="info.limpet.updatesite" label="Lightweight InforMation ProcEssing Toolkit - Limpet"/>
 </site>

--- a/info.limpet.product/limpet.product
+++ b/info.limpet.product/limpet.product
@@ -235,6 +235,7 @@ Library.
       <feature id="info.limpet.feature"/>
       <feature id="info.limpet.rcp.feature"/>
       <feature id="info.limpet.ui.feature"/>
+      <feature id="info.limpet.feature.libs"/>
    </features>
 
    <configurations>

--- a/info.limpet.site/category.xml
+++ b/info.limpet.site/category.xml
@@ -12,5 +12,8 @@
    <feature url="features/info.limpet.ui.feature_0.0.0.jar" id="info.limpet.ui.feature" version="0.0.0">
       <category name="info.limpet.updatesite"/>
    </feature>
+   <feature url="features/info.limpet.feature.libs_1.0.6.qualifier.jar" id="info.limpet.feature.libs" version="1.0.6.qualifier">
+      <category name="info.limpet.updatesite"/>
+   </feature>
    <category-def name="info.limpet.updatesite" label="Lightweight InforMation ProcEssing Toolkit - Limpet"/>
 </site>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>info.limpet.ui</module>
     <module>info.limpet.test</module>
     <module>info.limpet.feature</module>
+    <module>info.limpet.feature.libs</module>
     <module>info.limpet.rcp.feature</module>
     <module>info.limpet.ui.feature</module>
     <module>info.limpet.site</module>


### PR DESCRIPTION
Once this merge will re-add limpet update-site to Debrief target platform without any dependency conflicts 
