### PR TITLE
Support for empty Stacked Charts View, issue #355

### DIFF
--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
@@ -2,6 +2,7 @@ package info.limpet.stackedcharts.ui.editor.figures;
 
 import org.eclipse.draw2d.ActionListener;
 import org.eclipse.draw2d.Button;
+import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.Label;
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.swt.SWT;
@@ -24,14 +25,6 @@ public class ChartsetFigure extends DirectionalShape
     chartsetHeader = new DirectionalLabel(Activator.FONT_12);
     chartsetHeader.setText("Chart Set");
     chartsetHeader.setTextAlignment(PositionConstants.TOP);
-    if (boldFont == null)
-    {
-      FontData fontData = Display.getDefault().getActiveShell().getFont()
-          .getFontData()[0];
-      boldFont = new Font(Display.getDefault(), new FontData(fontData.getName(),
-          fontData.getHeight(), SWT.BOLD));
-    }
-    chartsetHeader.setFont(boldFont);
     add(chartsetHeader);
 
     Button button = new Button(StackedchartsImages.getImage(
@@ -46,6 +39,22 @@ public class ChartsetFigure extends DirectionalShape
   {
     super.setVertical(vertical);
     chartsetHeader.setVertical(vertical);
+  }
+  
+  @Override
+  public void paint(Graphics graphics)
+  {
+
+    if (boldFont == null)
+    {
+      FontData fontData = Display.getDefault().getActiveShell().getFont()
+          .getFontData()[0];
+      boldFont = new Font(Display.getDefault(), new FontData(fontData.getName(),
+          fontData.getHeight(), SWT.BOLD));
+      chartsetHeader.setFont(boldFont);
+    }
+
+    super.paint(graphics);
   }
 
 }

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
@@ -26,9 +26,9 @@ public class ChartsetFigure extends DirectionalShape
     chartsetHeader.setTextAlignment(PositionConstants.TOP);
     if (boldFont == null)
     {
-      FontData fontData = Display.getCurrent().getActiveShell().getFont()
+      FontData fontData = Display.getDefault().getActiveShell().getFont()
           .getFontData()[0];
-      boldFont = new Font(Display.getCurrent(), new FontData(fontData.getName(),
+      boldFont = new Font(Display.getDefault(), new FontData(fontData.getName(),
           fontData.getHeight(), SWT.BOLD));
     }
     chartsetHeader.setFont(boldFont);

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/figures/ChartsetFigure.java
@@ -51,8 +51,8 @@ public class ChartsetFigure extends DirectionalShape
           .getFontData()[0];
       boldFont = new Font(Display.getDefault(), new FontData(fontData.getName(),
           fontData.getHeight(), SWT.BOLD));
-      chartsetHeader.setFont(boldFont);
     }
+    chartsetHeader.setFont(boldFont);
 
     super.paint(graphics);
   }

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/ChartBuilder.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/ChartBuilder.java
@@ -558,7 +558,9 @@ public class ChartBuilder
     for(int ctr = 0; ctr < aCnt; ctr++)
     {
       ValueAxis axis = subplot.getRangeAxis(ctr);
-      axis.setLabel(null);
+      if (axis != null) {
+        axis.setLabel(null);
+      }
     }
 
     // add chart to stack

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
@@ -1,5 +1,11 @@
 package info.limpet.stackedcharts.ui.view;
 
+import info.limpet.stackedcharts.model.ChartSet;
+import info.limpet.stackedcharts.model.IndependentAxis;
+import info.limpet.stackedcharts.model.StackedchartsFactory;
+import info.limpet.stackedcharts.ui.editor.Activator;
+import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl;
+
 import java.awt.Color;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -10,8 +16,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.emf.common.util.URI;
@@ -60,12 +64,6 @@ import org.eclipse.ui.views.properties.tabbed.ITabbedPropertySheetPageContributo
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.StandardChartTheme;
 import org.jfree.experimental.chart.swt.ChartComposite;
-
-import info.limpet.stackedcharts.model.ChartSet;
-import info.limpet.stackedcharts.model.IndependentAxis;
-import info.limpet.stackedcharts.model.StackedchartsFactory;
-import info.limpet.stackedcharts.ui.editor.Activator;
-import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl;
 
 public class StackedChartsView extends ViewPart implements
     ITabbedPropertySheetPageContributor, ISelectionProvider, DisposeListener

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
@@ -354,7 +354,10 @@ public class StackedChartsView extends ViewPart implements
   {
     getViewSite().setSelectionProvider(this);// setup proxy selection provider
     stackedPane = new StackedPane(parent);
-    // not-null in case view is invoked from a "Show In ..." action 
+    
+    // note: The "Show in ..." action specifies a unique secondary id,
+    // which it uses to force a new instance.  Hence, if a secondary
+    // id isn't provided we presume a blank chart is being requested
     String secondaryId = ((IViewSite)getSite()).getSecondaryId();
     if (secondaryId != null) {
       
@@ -368,7 +371,7 @@ public class StackedChartsView extends ViewPart implements
       // order is different
       stackedPane.add(EDIT_VIEW, createEditView());
       stackedPane.add(CHART_VIEW, createChartView());
-      
+
       ChartSet blankModel = createBlankModel();
       setModel(blankModel, EDIT_VIEW);      
     }

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
@@ -1,9 +1,5 @@
 package info.limpet.stackedcharts.ui.view;
 
-import info.limpet.stackedcharts.model.ChartSet;
-import info.limpet.stackedcharts.ui.editor.Activator;
-import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl;
-
 import java.awt.Color;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -14,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.emf.common.util.URI;
@@ -54,6 +52,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.ui.views.properties.IPropertySheetPage;
@@ -61,6 +60,12 @@ import org.eclipse.ui.views.properties.tabbed.ITabbedPropertySheetPageContributo
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.StandardChartTheme;
 import org.jfree.experimental.chart.swt.ChartComposite;
+
+import info.limpet.stackedcharts.model.ChartSet;
+import info.limpet.stackedcharts.model.IndependentAxis;
+import info.limpet.stackedcharts.model.StackedchartsFactory;
+import info.limpet.stackedcharts.ui.editor.Activator;
+import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl;
 
 public class StackedChartsView extends ViewPart implements
     ITabbedPropertySheetPageContributor, ISelectionProvider, DisposeListener
@@ -351,12 +356,26 @@ public class StackedChartsView extends ViewPart implements
   {
     getViewSite().setSelectionProvider(this);// setup proxy selection provider
     stackedPane = new StackedPane(parent);
+    // not-null in case view is invoked from a "Show In ..." action 
+    String secondaryId = ((IViewSite)getSite()).getSecondaryId();
+    if (secondaryId != null) {
+      
+      stackedPane.add(CHART_VIEW, createChartView());
+      stackedPane.add(EDIT_VIEW, createEditView());
+      
+      selectView(CHART_VIEW);
+    } else {
 
-    stackedPane.add(CHART_VIEW, createChartView());
-    stackedPane.add(EDIT_VIEW, createEditView());
-
-    selectView(CHART_VIEW);
+      // blank view
+      // order is different
+      stackedPane.add(EDIT_VIEW, createEditView());
+      stackedPane.add(CHART_VIEW, createChartView());
+      
+      ChartSet blankModel = createBlankModel();
+      setModel(blankModel, EDIT_VIEW);      
+    }
     contributeToActionBars();
+
     chartEditor.init(this);
 
     // Drop Support for *.stackedcharts
@@ -460,13 +479,31 @@ public class StackedChartsView extends ViewPart implements
     addRunOnCloseCallback(dropMe);
   }
 
+  /**
+   * Creates an Chart Set with a single chart so that user would be able to drop datasets in it.
+   * 
+   * @return
+   */
+  private ChartSet createBlankModel() {
+    ChartSet chartSet = StackedchartsFactory.eINSTANCE.createChartSet();
+    chartSet.getCharts().add(StackedchartsFactory.eINSTANCE.createChart());
+    IndependentAxis independentAxis = StackedchartsFactory.eINSTANCE
+        .createIndependentAxis();
+    independentAxis.setAxisType(StackedchartsFactory.eINSTANCE
+        .createDateAxis());
+    chartSet.setSharedAxis(independentAxis);
+    return chartSet;
+  }
+  
   protected void fillLocalPullDown(final IMenuManager manager)
   {
   }
 
   protected void fillLocalToolBar(final IToolBarManager manager)
   {
-    manager.add(new Action("Edit", SWT.TOGGLE)
+    String actionText = stackedPane.getActiveControlKey() == CHART_VIEW ? "Edit"
+        : "View";
+    Action toggleViewModeAction = new Action(actionText, SWT.TOGGLE)
     {
       @Override
       public void run()
@@ -496,7 +533,8 @@ public class StackedChartsView extends ViewPart implements
           manager.update(true);
         }
       }
-    });
+    };
+    manager.add(toggleViewModeAction);
 
     final Action showTime = new Action("Show time marker", SWT.TOGGLE)
     {
@@ -548,8 +586,8 @@ public class StackedChartsView extends ViewPart implements
       {
         try
         {
-          final Clipboard clpbrd =
-              Toolkit.getDefaultToolkit().getSystemClipboard();
+          final Clipboard clpbrd = Toolkit.getDefaultToolkit()
+              .getSystemClipboard();
           clpbrd.setContents(new DrawableWMFTransfer(_chartComposite.getChart(),
               _chartComposite.getBounds()), null);
           MessageDialog.openInformation(Display.getCurrent().getActiveShell(),
@@ -754,6 +792,11 @@ public class StackedChartsView extends ViewPart implements
 
   public void setModel(final ChartSet charts)
   {
+    setModel(charts, CHART_VIEW);
+  }
+  
+  public void setModel(final ChartSet charts, int mode)
+  {
     this.charts = charts;
     // mark editor to recreate
     initEditor.set(true);
@@ -821,7 +864,7 @@ public class StackedChartsView extends ViewPart implements
 
     chartHolder.pack(true);
     chartHolder.getParent().layout();
-    selectView(CHART_VIEW);
+    selectView(mode);
   }
 
   @Override

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/view/StackedChartsView.java
@@ -354,26 +354,27 @@ public class StackedChartsView extends ViewPart implements
   {
     getViewSite().setSelectionProvider(this);// setup proxy selection provider
     stackedPane = new StackedPane(parent);
-    
+
     // note: The "Show in ..." action specifies a unique secondary id,
-    // which it uses to force a new instance.  Hence, if a secondary
+    // which it uses to force a new instance. Hence, if a secondary
     // id isn't provided we presume a blank chart is being requested
-    String secondaryId = ((IViewSite)getSite()).getSecondaryId();
-    if (secondaryId != null) {
-      
+    String secondaryId = ((IViewSite) getSite()).getSecondaryId();
+    if (secondaryId != null)
+    {
       stackedPane.add(CHART_VIEW, createChartView());
       stackedPane.add(EDIT_VIEW, createEditView());
-      
-      selectView(CHART_VIEW);
-    } else {
 
+      selectView(CHART_VIEW);
+    }
+    else
+    {
       // blank view
       // order is different
       stackedPane.add(EDIT_VIEW, createEditView());
       stackedPane.add(CHART_VIEW, createChartView());
 
       ChartSet blankModel = createBlankModel();
-      setModel(blankModel, EDIT_VIEW);      
+      setModel(blankModel, EDIT_VIEW);
     }
     contributeToActionBars();
 
@@ -485,25 +486,26 @@ public class StackedChartsView extends ViewPart implements
    * 
    * @return
    */
-  private ChartSet createBlankModel() {
+  private ChartSet createBlankModel()
+  {
     ChartSet chartSet = StackedchartsFactory.eINSTANCE.createChartSet();
     chartSet.getCharts().add(StackedchartsFactory.eINSTANCE.createChart());
-    IndependentAxis independentAxis = StackedchartsFactory.eINSTANCE
-        .createIndependentAxis();
-    independentAxis.setAxisType(StackedchartsFactory.eINSTANCE
-        .createDateAxis());
+    IndependentAxis independentAxis =
+        StackedchartsFactory.eINSTANCE.createIndependentAxis();
+    independentAxis
+        .setAxisType(StackedchartsFactory.eINSTANCE.createDateAxis());
     chartSet.setSharedAxis(independentAxis);
     return chartSet;
   }
-  
+
   protected void fillLocalPullDown(final IMenuManager manager)
   {
   }
 
   protected void fillLocalToolBar(final IToolBarManager manager)
   {
-    String actionText = stackedPane.getActiveControlKey() == CHART_VIEW ? "Edit"
-        : "View";
+    String actionText =
+        stackedPane.getActiveControlKey() == CHART_VIEW ? "Edit" : "View";
     Action toggleViewModeAction = new Action(actionText, SWT.TOGGLE)
     {
       @Override
@@ -587,10 +589,10 @@ public class StackedChartsView extends ViewPart implements
       {
         try
         {
-          final Clipboard clpbrd = Toolkit.getDefaultToolkit()
-              .getSystemClipboard();
-          clpbrd.setContents(new DrawableWMFTransfer(_chartComposite.getChart(),
-              _chartComposite.getBounds()), null);
+          final Clipboard clpbrd =
+              Toolkit.getDefaultToolkit().getSystemClipboard();
+          clpbrd.setContents(new DrawableWMFTransfer(
+              _chartComposite.getChart(), _chartComposite.getBounds()), null);
           MessageDialog.openInformation(Display.getCurrent().getActiveShell(),
               "Image Export", "Exported to Clipboard in WMF && PDF format");
 
@@ -795,7 +797,7 @@ public class StackedChartsView extends ViewPart implements
   {
     setModel(charts, CHART_VIEW);
   }
-  
+
   public void setModel(final ChartSet charts, int mode)
   {
     this.charts = charts;


### PR DESCRIPTION
https://github.com/debrief/limpet/issues/355

OK, the intention was to push to remote:origin (https://github.com/dinkoivanov/limpet), but Eclipse Git did push to remote:upstream, sorry for that. I hope that's not a problem, next time I will do from Source Tree or console,

In the end we use IViewSite.getSecondaryId() to check whether the view is invoked by a "Show In ..." action or user opened a blank view (Ctrl + 3 for example).
