### PR TITLE
394 undo redo on property changes

### DIFF
--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/StackedchartsEditControl.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/StackedchartsEditControl.java
@@ -1,5 +1,45 @@
 package info.limpet.stackedcharts.ui.editor;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EventObject;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.eclipse.draw2d.ColorConstants;
+import org.eclipse.emf.common.command.CommandStackListener;
+import org.eclipse.emf.ecore.provider.EcoreItemProviderAdapterFactory;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.edit.domain.IEditingDomainProvider;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory.Descriptor.Registry;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
+import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
+import org.eclipse.emf.edit.ui.view.ExtendedPropertySheetPage;
+import org.eclipse.gef.EditDomain;
+import org.eclipse.gef.GraphicalViewer;
+import org.eclipse.gef.editparts.AbstractEditPart;
+import org.eclipse.gef.ui.actions.RedoAction;
+import org.eclipse.gef.ui.actions.UndoAction;
+import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
+import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.views.properties.IPropertySheetPage;
+import org.eclipse.ui.views.properties.IPropertySource;
+import org.eclipse.ui.views.properties.PropertySheetPage;
+
 import info.limpet.stackedcharts.model.ChartSet;
 import info.limpet.stackedcharts.ui.editor.drop.DatasetToAxisDropTargetListener;
 import info.limpet.stackedcharts.ui.editor.drop.DatasetToAxisLandingDropTargetListener;
@@ -8,48 +48,39 @@ import info.limpet.stackedcharts.ui.editor.drop.ProxyDropTargetListener;
 import info.limpet.stackedcharts.ui.editor.drop.ScatterSetToScatterSetContainerTargetListener;
 import info.limpet.stackedcharts.ui.editor.parts.IPropertySourceProvider;
 import info.limpet.stackedcharts.ui.editor.parts.StackedChartsEditPartFactory;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EventObject;
-import java.util.List;
-
-import org.eclipse.draw2d.ColorConstants;
-import org.eclipse.emf.common.command.BasicCommandStack;
-import org.eclipse.emf.ecore.provider.EcoreItemProviderAdapterFactory;
-import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
-import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
-import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
-import org.eclipse.emf.edit.ui.view.ExtendedPropertySheetPage;
-import org.eclipse.gef.EditDomain;
-import org.eclipse.gef.GraphicalViewer;
-import org.eclipse.gef.commands.CommandStackListener;
-import org.eclipse.gef.editparts.AbstractEditPart;
-import org.eclipse.gef.ui.actions.RedoAction;
-import org.eclipse.gef.ui.actions.UndoAction;
-import org.eclipse.gef.ui.parts.ScrollingGraphicalViewer;
-import org.eclipse.jface.action.IToolBarManager;
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.StructuredSelection;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IActionBars;
-import org.eclipse.ui.IViewPart;
-import org.eclipse.ui.views.properties.IPropertySheetPage;
-import org.eclipse.ui.views.properties.IPropertySource;
+import info.limpet.stackedcharts.ui.emfgefstack.EmfGefCommandStack;
 
 public class StackedchartsEditControl extends Composite
 {
 
-  private final EditDomain editDomain;
+  private class CustomComposedAdapterFactory extends ComposedAdapterFactory
+      implements IEditingDomainProvider
+  {
+
+    private EditingDomain editingDomain;
+
+    public CustomComposedAdapterFactory(Registry instance)
+    {
+      super(instance);
+    }
+
+    @Override
+    public EditingDomain getEditingDomain()
+    {
+      return editingDomain;
+    }
+
+    public void setEditingDomain(EditingDomain editingDomain)
+    {
+      this.editingDomain = editingDomain;
+    }
+
+  }
+
   private final GraphicalViewer viewer;
 
   protected AdapterFactoryEditingDomain emfEditingDomain;
-  private ComposedAdapterFactory adapterFactory;
+  private CustomComposedAdapterFactory adapterFactory;
   private ExtendedPropertySheetPage propertySheetPage;
 
   public StackedchartsEditControl(Composite parent)
@@ -58,7 +89,10 @@ public class StackedchartsEditControl extends Composite
 
     setLayout(new FillLayout());
 
-    editDomain = new EditDomain();
+    EditDomain editDomain = new EditDomain();
+
+    EmfGefCommandStack commandStack = new EmfGefCommandStack();
+    editDomain.setCommandStack(commandStack.getWrappedGefCommandStack());
 
     viewer = new ScrollingGraphicalViewer();
 
@@ -69,8 +103,7 @@ public class StackedchartsEditControl extends Composite
         new DatasetToAxisDropTargetListener(viewer),
         new DatasetToAxisLandingDropTargetListener(viewer),
         new ScatterSetToScatterSetContainerTargetListener(viewer),
-        new DatasetToChartDropTargetListener(viewer)
-        ));
+        new DatasetToChartDropTargetListener(viewer)));
 
     viewer.createControl(this);
     editDomain.addViewer(viewer);
@@ -80,17 +113,16 @@ public class StackedchartsEditControl extends Composite
     viewer.setEditPartFactory(new StackedChartsEditPartFactory());
 
     // emf edit domain
-    adapterFactory =
-        new ComposedAdapterFactory(
-            ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
-    BasicCommandStack commandStack = new BasicCommandStack();
+    adapterFactory = new CustomComposedAdapterFactory(
+        ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
     adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
     adapterFactory.addAdapterFactory(new EcoreItemProviderAdapterFactory());
-    adapterFactory
-        .addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
-    emfEditingDomain =
-        new AdapterFactoryEditingDomain(adapterFactory, commandStack);
+    adapterFactory.addAdapterFactory(
+        new ReflectiveItemProviderAdapterFactory());
+    emfEditingDomain = new AdapterFactoryEditingDomain(adapterFactory,
+        commandStack);
 
+    adapterFactory.setEditingDomain(emfEditingDomain);    
   }
 
   /**
@@ -108,9 +140,9 @@ public class StackedchartsEditControl extends Composite
           StackedchartsEditControl.this.setSelectionToViewer(selection);
         }
       };
-      propertySheetPage
-          .setPropertySourceProvider(new AdapterFactoryContentProvider(
-              adapterFactory));
+      propertySheetPage.setPropertySourceProvider(
+          new AdapterFactoryContentProvider(adapterFactory));
+
     }
 
     return propertySheetPage;
@@ -134,11 +166,12 @@ public class StackedchartsEditControl extends Composite
         if (object instanceof AbstractEditPart)
         {
           AbstractEditPart abstractEditPart = (AbstractEditPart) object;
-          if(abstractEditPart instanceof IPropertySourceProvider)
+          if (abstractEditPart instanceof IPropertySourceProvider)
           {
-            IPropertySourceProvider mergeModelProvider = (IPropertySourceProvider) abstractEditPart; 
+            IPropertySourceProvider mergeModelProvider =
+                (IPropertySourceProvider) abstractEditPart;
             IPropertySource merged = mergeModelProvider.getPropertySource();
-            if(merged==null)
+            if (merged == null)
             {
               emfObj.add(abstractEditPart.getModel());
             }
@@ -170,8 +203,8 @@ public class StackedchartsEditControl extends Composite
 
           if (viewer != null)
           {
-            viewer
-                .setSelection(new StructuredSelection(theSelection.toArray()));
+            viewer.setSelection(new StructuredSelection(theSelection
+                .toArray()));
           }
         }
       };
@@ -197,12 +230,14 @@ public class StackedchartsEditControl extends Composite
 
     final UndoAction undoAction = new UndoAction(view);
     toolBarManager.add(undoAction);
-    undoAction.setImageDescriptor(Activator.imageDescriptorFromPlugin(Activator.PLUGIN_ID, "icons/undo.png"));
+    undoAction.setImageDescriptor(Activator.imageDescriptorFromPlugin(
+        Activator.PLUGIN_ID, "icons/undo.png"));
     final RedoAction redoAction = new RedoAction(view);
-    redoAction.setImageDescriptor(Activator.imageDescriptorFromPlugin(Activator.PLUGIN_ID, "icons/redo.png"));
+    redoAction.setImageDescriptor(Activator.imageDescriptorFromPlugin(
+        Activator.PLUGIN_ID, "icons/redo.png"));
     toolBarManager.add(redoAction);
 
-    viewer.getEditDomain().getCommandStack().addCommandStackListener(
+    emfEditingDomain.getCommandStack().addCommandStackListener(
         new CommandStackListener()
         {
 

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/parts/AxisEditPart.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/parts/AxisEditPart.java
@@ -6,6 +6,7 @@ import info.limpet.stackedcharts.model.ChartSet;
 import info.limpet.stackedcharts.model.DependentAxis;
 import info.limpet.stackedcharts.model.Orientation;
 import info.limpet.stackedcharts.model.StackedchartsPackage;
+import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl.EmfAwareViewer;
 import info.limpet.stackedcharts.ui.editor.commands.DeleteAxisFromChartCommand;
 import info.limpet.stackedcharts.ui.editor.figures.ArrowFigure;
 import info.limpet.stackedcharts.ui.editor.figures.AxisNameFigure;
@@ -245,7 +246,8 @@ public class AxisEditPart extends AbstractGraphicalEditPart implements
     final AxisType axisType = getAxis().getAxisType();
 
     // Proxy two objects in to one
-    return new CombinedProperty(axis, axisType, "Axis type");
+    return new CombinedProperty(axis, axisType, "Axis type",
+        ((EmfAwareViewer) getViewer()).getEditingDomain());
   }
 
 }

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/parts/DatasetEditPart.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/editor/parts/DatasetEditPart.java
@@ -8,6 +8,7 @@ import info.limpet.stackedcharts.model.Orientation;
 import info.limpet.stackedcharts.model.StackedchartsPackage;
 import info.limpet.stackedcharts.model.Styling;
 import info.limpet.stackedcharts.ui.editor.StackedchartsImages;
+import info.limpet.stackedcharts.ui.editor.StackedchartsEditControl.EmfAwareViewer;
 import info.limpet.stackedcharts.ui.editor.commands.DeleteDatasetsFromAxisCommand;
 import info.limpet.stackedcharts.ui.editor.figures.DatasetFigure;
 import info.limpet.stackedcharts.ui.editor.figures.DirectionalShape;
@@ -51,9 +52,8 @@ public class DatasetEditPart extends AbstractGraphicalEditPart implements
     contentPane = new DatasetFigure();
     figure.add(contentPane);
 
-    Button button =
-        new Button(StackedchartsImages
-            .getImage(StackedchartsImages.DESC_DELETE));
+    Button button = new Button(StackedchartsImages.getImage(
+        StackedchartsImages.DESC_DELETE));
     button.setToolTip(new Label("Remove the dataset from this axis"));
     button.addActionListener(this);
     figure.add(button);
@@ -71,7 +71,6 @@ public class DatasetEditPart extends AbstractGraphicalEditPart implements
   {
     return contentPane;
   }
-  
 
   @Override
   public IPropertySource getPropertySource()
@@ -80,7 +79,8 @@ public class DatasetEditPart extends AbstractGraphicalEditPart implements
     final Styling axisType = getDataset().getStyling();
 
     // Proxy two objects in to one
-    return new CombinedProperty(axis, axisType, "Styling");
+    return new CombinedProperty(axis, axisType, "Styling",
+        ((EmfAwareViewer) getViewer()).getEditingDomain());
   }
 
   @Override
@@ -94,8 +94,8 @@ public class DatasetEditPart extends AbstractGraphicalEditPart implements
       {
         Dataset dataset = (Dataset) getHost().getModel();
         DependentAxis parent = (DependentAxis) getHost().getParent().getModel();
-        DeleteDatasetsFromAxisCommand cmd =
-            new DeleteDatasetsFromAxisCommand(parent, dataset);
+        DeleteDatasetsFromAxisCommand cmd = new DeleteDatasetsFromAxisCommand(
+            parent, dataset);
         return cmd;
       }
     });
@@ -120,8 +120,8 @@ public class DatasetEditPart extends AbstractGraphicalEditPart implements
   {
     contentPane.setName(getDataset().getName());
 
-    ChartSet parent =
-        ((Chart) getParent().getParent().getParent().getModel()).getParent();
+    ChartSet parent = ((Chart) getParent().getParent().getParent().getModel())
+        .getParent();
 
     boolean horizontal = parent.getOrientation() == Orientation.HORIZONTAL;
     ((DirectionalShape) getFigure()).setVertical(!horizontal);

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/EmfCommandAdapter.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/EmfCommandAdapter.java
@@ -1,0 +1,111 @@
+package info.limpet.stackedcharts.ui.emfgefstack;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.gef.commands.Command;
+
+/**
+ * Adapts an EMF {@link org.eclipse.emf.common.command.Command} to a GEF {@link Command}
+ */
+public class EmfCommandAdapter extends Command
+{
+  private org.eclipse.emf.common.command.Command command;
+
+  public EmfCommandAdapter(org.eclipse.emf.common.command.Command command)
+  {
+    this.command = command;
+  }
+
+  public boolean canExecute()
+  {
+    return command == null ? false : command.canExecute();
+  }
+
+  public boolean canUndo()
+  {
+    return command == null ? false : command.canUndo();
+  }
+
+  public Command chain(Command command)
+  {
+    Command chained = this;
+    if (command != null)
+    {
+      org.eclipse.emf.common.command.Command emfCommand = null;
+      if (command instanceof EmfCommandAdapter)
+      {
+        emfCommand = ((EmfCommandAdapter) command).unwrap();
+      }
+      else
+      {
+        emfCommand = new GefCommandAdapter(command);
+      }
+      emfCommand = this.command.chain(emfCommand);
+      if (emfCommand != null)
+      {
+        if (emfCommand instanceof GefCommandAdapter)
+        {
+          chained = ((GefCommandAdapter) emfCommand).getGefCommand();
+        }
+        else
+        {
+          chained = new EmfCommandAdapter(emfCommand);
+        }
+      }
+    }
+    return chained;
+  }
+
+  public void dispose()
+  {
+    if (command != null)
+      command.dispose();
+  }
+
+  public void execute()
+  {
+    if (command != null)
+      command.execute();
+  }
+
+  public String getLabel()
+  {
+    return command == null ? this.getClass().getName() : command.getLabel();
+  }
+
+  public void redo()
+  {
+    if (command != null)
+      command.redo();
+  }
+
+  public void undo()
+  {
+    if (command != null)
+      command.undo();
+  }
+
+  public Collection getAffectedObjects()
+  {
+    return command == null ? Collections.EMPTY_LIST : command
+        .getAffectedObjects();
+  }
+
+  public String getDescription()
+  {
+    return command == null ? this.getClass().getName() : command
+        .getDescription();
+  }
+
+  public Collection getResult()
+  {
+    return command == null ? Collections.EMPTY_LIST : command.getResult();
+  }
+
+  public org.eclipse.emf.common.command.Command unwrap()
+  {
+    return command;
+  }
+
+}

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/EmfGefCommandStack.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/EmfGefCommandStack.java
@@ -1,0 +1,110 @@
+package info.limpet.stackedcharts.ui.emfgefstack;
+
+import java.util.EventObject;
+import java.util.Iterator;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.gef.commands.Command;
+import org.eclipse.gef.commands.CommandStack;
+import org.eclipse.gef.commands.CommandStackListener;
+
+/**
+ * An EMF {@link org.eclipse.emf.common.command.CommandStack} wrapping a GEF {@link CommandStack}.
+ * Source: http://www.eclipsezone.com/eclipse/forums/t46479.html
+ */
+public class EmfGefCommandStack extends BasicCommandStack
+{
+  private CommandStack wrappedGefCommandStack = new CommandStack()
+  {
+    public boolean canRedo()
+    {
+      return EmfGefCommandStack.this.canRedo();
+    }
+
+    public boolean canUndo()
+    {
+      return EmfGefCommandStack.this.canUndo();
+    }
+
+    public void execute(Command command)
+    {
+      if (command != null)
+      {
+        org.eclipse.emf.common.command.Command emfCommand = null;
+        if (command instanceof EmfCommandAdapter)
+        {
+          emfCommand = ((EmfCommandAdapter) command).unwrap();
+        }
+        else
+        {
+          emfCommand = new GefCommandAdapter(command);
+        }
+        EmfGefCommandStack.this.execute(emfCommand);
+      }
+    }
+
+    public void flush()
+    {
+      EmfGefCommandStack.this.flush();
+    }
+
+    public Command getRedoCommand()
+    {
+      org.eclipse.emf.common.command.Command command = EmfGefCommandStack.this
+          .getRedoCommand();
+      Command gefCommand = null;
+      if (command != null)
+      {
+        if (command instanceof GefCommandAdapter)
+        {
+          gefCommand = ((GefCommandAdapter) command).getGefCommand();
+        }
+        else
+        {
+          gefCommand = new EmfCommandAdapter(command);
+        }
+      }
+      return gefCommand;
+    }
+
+    public Command getUndoCommand()
+    {
+      return null;
+    }
+
+    public void redo()
+    {
+      EmfGefCommandStack.this.redo();
+    }
+
+    public void undo()
+    {
+      EmfGefCommandStack.this.undo();
+    }
+
+  };
+
+  public CommandStack getWrappedGefCommandStack()
+  {
+    return wrappedGefCommandStack;
+  }
+
+  protected void notifyListeners()
+  {
+    for (Iterator i = listeners.iterator(); i.hasNext();)
+    {
+      Object listener = i.next();
+      if (listener instanceof org.eclipse.emf.common.command.CommandStackListener)
+      {
+        ((org.eclipse.emf.common.command.CommandStackListener) listener)
+            .commandStackChanged(new EventObject(this));
+      }
+      else
+      {
+        ((CommandStackListener) listener).commandStackChanged(new EventObject(
+            wrappedGefCommandStack));
+      }
+    }
+  }
+
+}

--- a/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/GefCommandAdapter.java
+++ b/info.limpet.stackedcharts.ui/src/info/limpet/stackedcharts/ui/emfgefstack/GefCommandAdapter.java
@@ -1,0 +1,108 @@
+package info.limpet.stackedcharts.ui.emfgefstack;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.emf.common.command.Command;
+
+/**
+ * Adapts a GEF {@link org.eclipse.gef.commands.Command} to the {@link Command} interface of EMF
+ */
+public class GefCommandAdapter implements Command
+{
+  private org.eclipse.gef.commands.Command command;
+
+  public GefCommandAdapter(org.eclipse.gef.commands.Command command)
+  {
+    this.command = command;
+  }
+
+  public boolean canExecute()
+  {
+    return command == null ? false : command.canExecute();
+  }
+
+  public boolean canUndo()
+  {
+    return command == null ? false : command.canUndo();
+  }
+
+  public Command chain(Command command)
+  {
+    Command chained = this;
+    if (command != null)
+    {
+      org.eclipse.gef.commands.Command gefCommand = null;
+      if (command instanceof GefCommandAdapter)
+      {
+        gefCommand = ((GefCommandAdapter) command).getGefCommand();
+      }
+      else
+      {
+        gefCommand = new EmfCommandAdapter(command);
+      }
+      gefCommand = this.command.chain(gefCommand);
+      if (gefCommand != null)
+      {
+        if (gefCommand instanceof EmfCommandAdapter)
+        {
+          chained = ((EmfCommandAdapter) gefCommand).unwrap();
+        }
+        else
+        {
+          chained = new GefCommandAdapter(gefCommand);
+        }
+      }
+    }
+    return chained;
+  }
+
+  public void dispose()
+  {
+    if (command != null)
+      command.dispose();
+  }
+
+  public void execute()
+  {
+    if (command != null)
+      command.execute();
+  }
+
+  public Collection getAffectedObjects()
+  {
+    return Collections.EMPTY_LIST;
+  }
+
+  public String getDescription()
+  {
+    return this.getClass().getName();
+  }
+
+  public String getLabel()
+  {
+    return command == null ? getDescription() : command.getLabel();
+  }
+
+  public Collection getResult()
+  {
+    return Collections.EMPTY_LIST;
+  }
+
+  public void redo()
+  {
+    if (command != null)
+      command.redo();
+  }
+
+  public void undo()
+  {
+    if (command != null)
+      command.undo();
+  }
+
+  public org.eclipse.gef.commands.Command getGefCommand()
+  {
+    return command;
+  }
+}


### PR DESCRIPTION
The solution involved contributing a custom EMF-GEF 'bridging' command stack inspired from [here](http://www.eclipsezone.com/eclipse/forums/t46479.html).
This stack allows EMF commands (used in the properties view) to be reflected properly in the Undo/Redo actions in the stacked charts editor.
In addition a change was introduced in the CombinedProperty (the one that's responsible to proxy two objects into one for the properties view). This was needed to handle the Undo/Redo when editing via the property sheet.
